### PR TITLE
renderer: add support for extending node renderers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run linters
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52.2
+          version: v1.56.0
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  go_version: 1.18.x
+  go_version: 1.21.x
 
 jobs:
   lint:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/teekennedy/goldmark-markdown
 
-go 1.18
+go 1.21
 
 require (
 	github.com/rhysd/go-fakeio v1.0.0

--- a/renderer.go
+++ b/renderer.go
@@ -146,10 +146,10 @@ func (r *Renderer) renderBlockSeparator(node ast.Node, entering bool) ast.WalkSt
 func (r *Renderer) renderAutoLink(node ast.Node, entering bool) ast.WalkStatus {
 	n := node.(*ast.AutoLink)
 	if entering {
-		r.rc.writer.Write([]byte("<"))
-		r.rc.writer.Write(n.URL(r.rc.source))
+		r.rc.writer.WriteBytes([]byte("<"))
+		r.rc.writer.WriteBytes(n.URL(r.rc.source))
 	} else {
-		r.rc.writer.Write([]byte(">"))
+		r.rc.writer.WriteBytes([]byte(">"))
 	}
 	return ast.WalkContinue
 }
@@ -182,15 +182,15 @@ func (r *Renderer) renderHeading(node ast.Node, entering bool) ast.WalkStatus {
 
 func (r *Renderer) renderATXHeading(node *ast.Heading, entering bool) ast.WalkStatus {
 	if entering {
-		r.rc.writer.Write(bytes.Repeat([]byte("#"), node.Level))
+		r.rc.writer.WriteBytes(bytes.Repeat([]byte("#"), node.Level))
 		// Only print space after heading if non-empty
 		if node.HasChildren() {
-			r.rc.writer.Write([]byte(" "))
+			r.rc.writer.WriteBytes([]byte(" "))
 		}
 	} else {
 		if r.config.HeadingStyle == HeadingStyleATXSurround {
-			r.rc.writer.Write([]byte(" "))
-			r.rc.writer.Write(bytes.Repeat([]byte("#"), node.Level))
+			r.rc.writer.WriteBytes([]byte(" "))
+			r.rc.writer.WriteBytes(bytes.Repeat([]byte("#"), node.Level))
 		}
 	}
 	return ast.WalkContinue
@@ -213,8 +213,8 @@ func (r *Renderer) renderSetextHeading(node *ast.Heading, entering bool) ast.Wal
 			}
 		}
 	}
-	r.rc.writer.Write([]byte("\n"))
-	r.rc.writer.Write(bytes.Repeat(underlineChar, underlineWidth))
+	r.rc.writer.WriteBytes([]byte("\n"))
+	r.rc.writer.WriteBytes(bytes.Repeat(underlineChar, underlineWidth))
 	return ast.WalkContinue
 }
 
@@ -228,7 +228,7 @@ func (r *Renderer) renderThematicBreak(node ast.Node, entering bool) ast.WalkSta
 		} else {
 			breakLen = int(r.config.ThematicBreakLength)
 		}
-		r.rc.writer.Write(bytes.Repeat(breakChar, breakLen))
+		r.rc.writer.WriteBytes(bytes.Repeat(breakChar, breakLen))
 	}
 	return ast.WalkContinue
 }
@@ -245,10 +245,10 @@ func (r *Renderer) renderCodeBlock(node ast.Node, entering bool) ast.WalkStatus 
 
 func (r *Renderer) renderFencedCodeBlock(node ast.Node, entering bool) ast.WalkStatus {
 	n := node.(*ast.FencedCodeBlock)
-	r.rc.writer.Write([]byte("```"))
+	r.rc.writer.WriteBytes([]byte("```"))
 	if entering {
 		if info := n.Info; info != nil {
-			r.rc.writer.Write(info.Text(r.rc.source))
+			r.rc.writer.WriteBytes(info.Text(r.rc.source))
 		}
 		r.rc.writer.FlushLine()
 		r.renderLines(node, entering)
@@ -315,7 +315,7 @@ func (r *Renderer) renderText(node ast.Node, entering bool) ast.WalkStatus {
 	if entering {
 		text := n.Text(r.rc.source)
 
-		r.rc.writer.Write(text)
+		r.rc.writer.WriteBytes(text)
 		if n.SoftLineBreak() {
 			r.rc.writer.EndLine()
 		}
@@ -327,7 +327,7 @@ func (r *Renderer) renderSegments(segments *text.Segments, asLines bool) {
 	for i := 0; i < segments.Len(); i++ {
 		segment := segments.At(i)
 		value := segment.Value(r.rc.source)
-		r.rc.writer.Write(value)
+		r.rc.writer.WriteBytes(value)
 		if asLines {
 			r.rc.writer.FlushLine()
 		}
@@ -350,32 +350,32 @@ func (r *Renderer) renderLink(node ast.Node, entering bool) ast.WalkStatus {
 func (r *Renderer) renderImage(node ast.Node, entering bool) ast.WalkStatus {
 	n := node.(*ast.Image)
 	if entering {
-		r.rc.writer.Write([]byte("!"))
+		r.rc.writer.WriteBytes([]byte("!"))
 	}
 	return r.renderLinkCommon(n.Title, n.Destination, entering)
 }
 
 func (r *Renderer) renderLinkCommon(title, destination []byte, entering bool) ast.WalkStatus {
 	if entering {
-		r.rc.writer.Write([]byte("["))
+		r.rc.writer.WriteBytes([]byte("["))
 	} else {
-		r.rc.writer.Write([]byte("]("))
-		r.rc.writer.Write(destination)
+		r.rc.writer.WriteBytes([]byte("]("))
+		r.rc.writer.WriteBytes(destination)
 		if len(title) > 0 {
-			r.rc.writer.Write([]byte(" \""))
-			r.rc.writer.Write(title)
-			r.rc.writer.Write([]byte("\""))
+			r.rc.writer.WriteBytes([]byte(" \""))
+			r.rc.writer.WriteBytes(title)
+			r.rc.writer.WriteBytes([]byte("\""))
 		}
-		r.rc.writer.Write([]byte(")"))
+		r.rc.writer.WriteBytes([]byte(")"))
 	}
 	return ast.WalkContinue
 }
 
 func (r *Renderer) renderCodeSpan(node ast.Node, entering bool) ast.WalkStatus {
 	if bytes.Count(node.Text(r.rc.source), []byte("`"))%2 != 0 {
-		r.rc.writer.Write([]byte("``"))
+		r.rc.writer.WriteBytes([]byte("``"))
 	} else {
-		r.rc.writer.Write([]byte("`"))
+		r.rc.writer.WriteBytes([]byte("`"))
 	}
 
 	return ast.WalkContinue
@@ -383,7 +383,7 @@ func (r *Renderer) renderCodeSpan(node ast.Node, entering bool) ast.WalkStatus {
 
 func (r *Renderer) renderEmphasis(node ast.Node, entering bool) ast.WalkStatus {
 	n := node.(*ast.Emphasis)
-	r.rc.writer.Write(bytes.Repeat([]byte{'*'}, n.Level))
+	r.rc.writer.WriteBytes(bytes.Repeat([]byte{'*'}, n.Level))
 	return ast.WalkContinue
 }
 

--- a/renderer.go
+++ b/renderer.go
@@ -105,6 +105,7 @@ func (r *Renderer) Render(w io.Writer, source []byte, n ast.Node) error {
 	})
 }
 
+// transform wraps a renderer.NodeRendererFunc to match the nodeRenderer function signature
 func (r *Renderer) transform(fn renderer.NodeRendererFunc) nodeRenderer {
 	return func(n ast.Node, entering bool) ast.WalkStatus {
 		status, _ := fn(r.rc.writer, r.rc.source, n, entering)

--- a/renderer_test.go
+++ b/renderer_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/text"
 	"github.com/yuin/goldmark/util"
@@ -59,9 +60,26 @@ func TestRenderError(t *testing.T) {
 	assert.Equal(t, err, result)
 }
 
+// TestCustomRenderers tests that the renderer uses any config.NodeRenderers defined by the user
+func TestCustomRenderers(t *testing.T) {
+	md := goldmark.New(
+		goldmark.WithRenderer(NewRenderer()),
+		goldmark.WithParserOptions(parser.WithASTTransformers(util.Prioritized(&transformer, 0))),
+	)
+	buf := bytes.Buffer{}
+	source := `# My Tasks
+- [x] Add support for custom renderers
+	`
+
+	extension.TaskList.Extend(md)
+	err := md.Convert([]byte(source), &buf)
+	assert.NoError(t, err)
+	t.Log(buf.String())
+}
+
 // TestRenderedOutput tests that the renderer produces the expected output for all test cases
 func TestRenderedOutput(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		name     string
 		options  []Option
 		source   string

--- a/writer.go
+++ b/writer.go
@@ -75,7 +75,7 @@ func (m *markdownWriter) FlushLine() {
 
 // EndLine ends the current line, flushing the line buffer regardless of whether it's empty.
 func (m *markdownWriter) EndLine() {
-	m.Write([]byte{lineDelim})
+	_, _ = m.Write([]byte{lineDelim})
 }
 
 // PushPrefix adds the given bytes as a prefix for lines written to the output. The prefix
@@ -103,8 +103,12 @@ func (p *markdownWriter) PopPrefix() {
 // Write writes the given data to an internal buffer, then writes any complete lines to the
 // underlying writer.
 func (m *markdownWriter) Write(data []byte) (n int, err error) {
+	return m.WriteBytes(data), m.err
+}
+
+func (m *markdownWriter) WriteBytes(data []byte) (n int) {
 	if m.err != nil {
-		return 0, m.err
+		return 0
 	}
 	// Writing to a bytes.Buffer always returns a nil error
 	n, _ = m.buf.Write(data)
@@ -127,12 +131,12 @@ func (m *markdownWriter) Write(data []byte) (n int, err error) {
 		_, err := m.output.Write(prefixedLine.Bytes())
 		if err != nil {
 			m.err = err
-			return 0, m.err
+			return 0
 		}
 		m.line += 1
 		prefixedLine.Reset()
 	}
-	return n, nil
+	return n
 }
 
 // Err returns the last write error, or nil.

--- a/writer.go
+++ b/writer.go
@@ -140,21 +140,19 @@ func (m *markdownWriter) Err() error {
 	return m.err
 }
 
-// returns how many bytes are unused in the buffer.
+// Available returns how many bytes are unused in the buffer.
 func (m *markdownWriter) Available() int {
-	return m.buf.Cap() - m.buf.Len()
+	return m.buf.Available()
 }
 
+// Buffered returns the number of bytes that have been written into the current buffer.
 func (m *markdownWriter) Buffered() int {
 	return m.buf.Len()
 }
 
+// Flush flushes the contents of the buffer to the output.
 func (m *markdownWriter) Flush() error {
-	_, err := m.output.Write(m.buf.Bytes())
-	if err != nil {
-		return err
-	}
-	m.buf.Reset()
+	m.FlushLine()
 	return nil
 }
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -160,15 +160,19 @@ func TestWriteError(t *testing.T) {
 	writer := newMarkdownWriter(&ew, NewConfig())
 	data := []byte("foo\n")
 
-	assert.Equal(len(data), writer.Write(data), "Writes should succeed before error")
+	var n int
+	n, _ = writer.Write(data)
+	assert.Equal(len(data), n, "Writes should succeed before error")
 	assert.Equal(len(data), writer.WriteLine(data), "Writes should succeed before error")
 	ew.err = err
-	assert.Equal(0, writer.Write(data), "Once error is set, writes become no-op")
+	n, _ = writer.Write(data)
+	assert.Equal(0, n, "Once error is set, writes become no-op")
 	assert.Equal(0, writer.WriteLine(data), "Once error is set, writes become no-op")
 	assert.Equal(err, writer.Err(), "Err() should match error returned by errorWriter")
 
 	ew.err = nil
 	writer.Reset(&ew)
-	assert.Equal(len(data), writer.Write(data), "Writes should succeed after Reset")
+	n, _ = writer.Write(data)
+	assert.Equal(len(data), n, "Writes should succeed after Reset")
 	assert.Equal(len(data), writer.WriteLine(data), "Writes should succeed after Reset")
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -18,16 +18,21 @@ func TestWrite(t *testing.T) {
 	assert.Equal(t, 0, available)
 	assert.Equal(t, 0, writer.Buffered())
 
-	writer.WriteByte(byte('b'))
-	writer.WriteRune('r')
-	writer.WriteString("s")
+	err := writer.WriteByte(byte('b'))
+	require.NoError(t, err)
+	_, err = writer.Write([]byte("y"))
+	require.NoError(t, err)
+	_, err = writer.WriteRune('t')
+	require.NoError(t, err)
+	_, err = writer.WriteString("e")
+	require.NoError(t, err)
 
 	assert.Less(t, available, writer.Available())
-	assert.Equal(t, 3, writer.Buffered())
+	assert.Equal(t, 4, writer.Buffered())
 
-	err := writer.Flush()
+	err = writer.Flush()
 	require.NoError(t, err)
-	assert.Equal(t, "brs\n", buf.String())
+	assert.Equal(t, "byte\n", buf.String())
 }
 
 // TestFlushLine tests that the writer will flush the current buffered line if non-empty.
@@ -38,7 +43,7 @@ func TestFlushLine(t *testing.T) {
 
 	writer.FlushLine()
 	assert.Equal("", buf.String(), "FlushLine() on an empty buffer should not produce output")
-	writer.Write([]byte("foobar"))
+	writer.WriteBytes([]byte("foobar"))
 	writer.FlushLine()
 	assert.Equal("foobar\n", buf.String(), "FlushLine() on partial line should produce output.")
 }
@@ -51,7 +56,7 @@ func TestEndLine(t *testing.T) {
 
 	writer.EndLine()
 	assert.Equal("\n", buf.String(), "EndLine() should write newline to output")
-	writer.Write([]byte("A line"))
+	writer.WriteBytes([]byte("A line"))
 	assert.Equal("\n", buf.String(), "Writing a partial line should not produce output.")
 	writer.FlushLine()
 	assert.Equal("\nA line\n", buf.String(), "FlushLine() on partial line should produce output.")
@@ -100,7 +105,7 @@ func TestWriterOutputs(t *testing.T) {
 			func(writer *markdownWriter) {
 				lines := []string{"Consider me", "As one who loved poetry", "And persimmons."}
 				writer.PushPrefix([]byte("  "), 1)
-				writer.Write([]byte("- "))
+				writer.WriteBytes([]byte("- "))
 				for _, line := range lines {
 					writer.WriteLine([]byte(line))
 				}

--- a/writer_test.go
+++ b/writer_test.go
@@ -7,7 +7,28 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestWrite(t *testing.T) {
+	buf := &bytes.Buffer{}
+	writer := newMarkdownWriter(buf, NewConfig())
+
+	available := writer.Available()
+	assert.Equal(t, 0, available)
+	assert.Equal(t, 0, writer.Buffered())
+
+	writer.WriteByte(byte('b'))
+	writer.WriteRune('r')
+	writer.WriteString("s")
+
+	assert.Less(t, available, writer.Available())
+	assert.Equal(t, 3, writer.Buffered())
+
+	err := writer.Flush()
+	require.NoError(t, err)
+	assert.Equal(t, "brs\n", buf.String())
+}
 
 // TestFlushLine tests that the writer will flush the current buffered line if non-empty.
 func TestFlushLine(t *testing.T) {
@@ -38,7 +59,7 @@ func TestEndLine(t *testing.T) {
 
 // TestWriterOutputs tests that the writer produces expected output in various scenarios.
 func TestWriterOutputs(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		name      string
 		writeFunc func(writer *markdownWriter)
 		expected  string


### PR DESCRIPTION
Hi, I added support for extending node renderer similar to goldmark's HTML renderer.

An example usage:
```go
markdownRenderer := markdown.NewRenderer()
markdownRenderer.AddOptions(
	renderer.WithNodeRenderers(util.Prioritized(&latex.BlockRenderer{
		RendererType: latex.RendererTypeMarkdown,
	}, 502)),
)
md := goldmark.New(
	goldmark.WithRenderer(markdownRenderer),
)	
```